### PR TITLE
Fix invocation of `gentoo-packages` without subcommand

### DIFF
--- a/binary_gentoo/internal/cli/packages.py
+++ b/binary_gentoo/internal/cli/packages.py
@@ -155,7 +155,7 @@ def parse_command_line(argv):
     add_version_argument_to(parser)
     add_pkgdir_argument_to(parser)
 
-    subcommands = parser.add_subparsers(title='subcommands')
+    subcommands = parser.add_subparsers(title='subcommands', required=True)
 
     delete_command = subcommands.add_parser('delete',
                                             help='drop package entries and '


### PR DESCRIPTION
Symptom was:

```console
# gentoo-packages --pkgdir XXX
ERROR: 'Namespace' object has no attribute 'command_func'
```