### PR TITLE
Mark command line arguments as required that cannot be auto-detected

### DIFF
--- a/binary_gentoo/internal/cli/_distro.py
+++ b/binary_gentoo/internal/cli/_distro.py
@@ -1,0 +1,6 @@
+# Copyright (C) 2024 Sebastian Pipping <sebastian@pipping.org>
+# Licensed under GNU Affero GPL version 3 or later
+
+import os
+
+HOST_IS_GENTOO = os.path.exists('/etc/gentoo-release')

--- a/binary_gentoo/internal/cli/_parser.py
+++ b/binary_gentoo/internal/cli/_parser.py
@@ -2,6 +2,7 @@
 # Licensed under GNU Affero GPL version 3 or later
 
 from ..version import VERSION_STR
+from ._distro import HOST_IS_GENTOO
 
 
 def add_version_argument_to(parser):
@@ -28,25 +29,35 @@ def add_portdir_argument_to(parser):
         '--portdir',
         dest='host_portdir',
         metavar='DIR',
-        help=(
-            'enforce specific location for PORTDIR'
-            ' (e.g. "/var/db/repos/gentoo" or "/usr/portage", default: auto-detect using portageq)'
-        ))
+        required=not HOST_IS_GENTOO,
+        help=(('enforce specific location for PORTDIR'
+               ' (e.g. "/var/db/repos/gentoo" or "/usr/portage"'
+               ', default: auto-detect using portageq)') if HOST_IS_GENTOO else
+              ('specify PORTDIR'
+               ' (required, would be e.g. "/var/db/repos/gentoo" or "/usr/portage" on Gentoo)')))
 
 
 def add_distdir_argument_to(parser):
-    parser.add_argument('--distdir',
-                        dest='host_distdir',
-                        metavar='DIR',
-                        help='enforce specific location for DISTDIR'
-                        ' (e.g. "/var/cache/distfiles" or "/usr/portage/distfiles", '
-                        'default: auto-detect using portageq)')
+    parser.add_argument(
+        '--distdir',
+        dest='host_distdir',
+        metavar='DIR',
+        required=not HOST_IS_GENTOO,
+        help=(('enforce specific location for DISTDIR'
+               ' (e.g. "/var/cache/distfiles" or "/usr/portage/distfiles"'
+               ', default: auto-detect using portageq)') if HOST_IS_GENTOO else
+              ('specify DISTDIR (required'
+               ', would be e.g. "/var/cache/distfiles" or "/usr/portage/distfiles" on Gentoo)')))
 
 
 def add_pkgdir_argument_to(parser):
-    parser.add_argument('--pkgdir',
-                        dest='host_pkgdir',
-                        metavar='DIR',
-                        help='enforce specific location for PKGDIR'
-                        ' (e.g. "/var/cache/binpkgs" or "/usr/portage/packages", '
-                        'default: auto-detect using portageq)')
+    parser.add_argument(
+        '--pkgdir',
+        dest='host_pkgdir',
+        metavar='DIR',
+        required=not HOST_IS_GENTOO,
+        help=(('enforce specific location for PKGDIR'
+               ' (e.g. "/var/cache/binpkgs" or "/usr/portage/packages"'
+               ', default: auto-detect using portageq)') if HOST_IS_GENTOO else
+              ('specify PKGDIR (required'
+               ', would be e.g. "/var/cache/binpkgs" or "/usr/portage/packages" on Gentoo)')))

--- a/binary_gentoo/internal/cli/build.py
+++ b/binary_gentoo/internal/cli/build.py
@@ -19,6 +19,7 @@ import yaml
 
 from ..atoms import ATOM_LIKE_DISPLAY, SET_DISPLAY, extract_category_package_from, extract_set_from
 from ..reporter import announce_and_call, announce_and_check_output, exception_reporting
+from ._distro import HOST_IS_GENTOO
 from ._enrich import enrich_host_distdir_of, enrich_host_pkgdir_of, enrich_host_portdir_of
 from ._parser import (add_distdir_argument_to, add_docker_image_argument_to,
                       add_interactive_argument_to, add_pkgdir_argument_to, add_portdir_argument_to,
@@ -77,8 +78,10 @@ def parse_command_line(argv):
     parser.add_argument(
         '--gentoo-profile',
         metavar='PROFILE',
-        help='enforce Gentoo profile PROFILE'
-        ' (e.g. "default/linux/amd64/17.1/developer", default: auto-detect using eselect)')
+        required=not HOST_IS_GENTOO,
+        help=(('enforce Gentoo profile PROFILE'
+               ' (e.g. "default/linux/amd64/17.1/developer", default: auto-detect using eselect)')
+              if HOST_IS_GENTOO else 'specify Gentoo profile PROFILE (required)'))
 
     parser.add_argument('--use', help='custom one-off use flags (default: none)')
 
@@ -88,17 +91,25 @@ def parse_command_line(argv):
                         help='enforce custom MAKEOPTS (default: "%(default)s")')
     parser.add_argument('--cflags',
                         metavar='CFLAGS',
-                        help='enforce custom CFLAGS (default: auto-detect using portageq)')
+                        required=not HOST_IS_GENTOO,
+                        help=('enforce custom CFLAGS (default: auto-detect using portageq)'
+                              if HOST_IS_GENTOO else 'specify CFLAGS (required)'))
     parser.add_argument('--cxxflags',
                         metavar='CXXFLAGS',
-                        help='enforce custom CXXFLAGS (default: auto-detect using portageq)')
+                        required=not HOST_IS_GENTOO,
+                        help=('enforce custom CXXFLAGS (default: auto-detect using portageq)'
+                              if HOST_IS_GENTOO else 'specify CXXFLAGS (required)'))
     parser.add_argument('--ldflags',
                         metavar='LDFLAGS',
-                        help='enforce custom LDFLAGS (default: auto-detect using portageq)')
+                        required=not HOST_IS_GENTOO,
+                        help=('enforce custom LDFLAGS (default: auto-detect using portageq)'
+                              if HOST_IS_GENTOO else 'specify LDFLAGS (required)'))
     parser.add_argument('--cpu-flags-x86',
                         metavar='FLAGS',
-                        help='enforce custom CPU_FLAGS_X86'
-                        ' (default: auto-detect using portageq (not cpuid2cpuflags))')
+                        required=not HOST_IS_GENTOO,
+                        help=(('enforce custom CPU_FLAGS_X86'
+                               ' (default: auto-detect using portageq (not cpuid2cpuflags))')
+                              if HOST_IS_GENTOO else 'specify CPU_FLAGS_X86 (required)'))
 
     add_portdir_argument_to(parser)
     add_pkgdir_argument_to(parser)

--- a/binary_gentoo/internal/cli/tests/test_build.py
+++ b/binary_gentoo/internal/cli/tests/test_build.py
@@ -68,7 +68,9 @@ class EnrichConfigTest(TestCase):
         return (output + '\n').encode('ascii')
 
     def test_portagq_interaction(self):
-        config = parse_command_line(['gentoo-build', 'cat/pkg'])
+        with patch('binary_gentoo.internal.cli.build.HOST_IS_GENTOO', True), \
+                patch('binary_gentoo.internal.cli._parser.HOST_IS_GENTOO', True):
+            config = parse_command_line(['gentoo-build', 'cat/pkg'])
 
         with patch('subprocess.check_output', self._fake_subprocess_check_output), \
                 patch('sys.stdout', StringIO()):

--- a/binary_gentoo/internal/cli/tests/test_tree_diff.py
+++ b/binary_gentoo/internal/cli/tests/test_tree_diff.py
@@ -56,7 +56,8 @@ class EnrichConfigTest(TestCase):
         self.assertEqual(config.keywords, {'one', 'two', '~two', '*'})
 
     def test_not_given__auto_detection(self):
-        config = parse_command_line(['gentoo-tree-diff', 'dir1', 'dir2'])
+        with patch('binary_gentoo.internal.cli.tree_diff.HOST_IS_GENTOO', True):
+            config = parse_command_line(['gentoo-tree-diff', 'dir1', 'dir2'])
         with patch('subprocess.check_output', self._fake_subprocess_check_output), \
                 patch('sys.stdout', StringIO()):
             enrich_config(config)

--- a/binary_gentoo/internal/cli/tree_diff.py
+++ b/binary_gentoo/internal/cli/tree_diff.py
@@ -9,6 +9,7 @@ from argparse import ArgumentParser
 from typing import Set
 
 from ..reporter import announce_and_check_output, exception_reporting
+from ._distro import HOST_IS_GENTOO
 from ._parser import add_version_argument_to
 
 _keywords_pattern = re.compile('KEYWORDS="(?P<keywords>[^"]*)"')
@@ -120,9 +121,10 @@ def parse_command_line(argv):
     add_version_argument_to(parser)
 
     parser.add_argument('--keywords',
+                        required=not HOST_IS_GENTOO,
                         help='include only packages/versions/revisions that have these keywords; '
-                        'in case of multiple keywords a space-separated list can be provided '
-                        '(default: auto-detect using portageq)')
+                        'in case of multiple keywords a space-separated list can be provided'
+                        f'{" (default: auto-detect using portageq)" if HOST_IS_GENTOO else ""}')
 
     parser.add_argument('--pessimistic',
                         default=False,


### PR DESCRIPTION
.. on non-Gentoo distributions of Linux