### PR TITLE
Migrate to Gentoo profile `default/linux/amd64/23.0` (merged-usr)

### DIFF
--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -79,7 +79,7 @@ jobs:
 
           gentoo-build \
               --non-interactive \
-              --gentoo-profile default/linux/amd64/17.1/developer \
+              --gentoo-profile default/linux/amd64/23.0 \
               --cflags '-O0 -pipe' \
               --cxxflags '-O0 -pipe' \
               --ldflags '-Wl,-O0 -Wl,--as-needed' \

--- a/binary_gentoo/internal/cli/build.py
+++ b/binary_gentoo/internal/cli/build.py
@@ -90,7 +90,7 @@ def parse_command_line(argv):
         help=(
             (
                 "enforce Gentoo profile PROFILE"
-                ' (e.g. "default/linux/amd64/17.1/developer", default: auto-detect using eselect)'
+                ' (e.g. "default/linux/amd64/23.0", default: auto-detect using eselect)'
             )
             if HOST_IS_GENTOO
             else "specify Gentoo profile PROFILE (required)"


### PR DESCRIPTION
.. because current profile `default/linux/amd64/17.1/developer` (split-usr) will be removed soon