### PR TITLE
`smoke_test.yml`: Build something smaller than recent `media-gfx/optipng`

### DIFF
--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -89,13 +89,13 @@ jobs:
               --distdir distfiles/ \
               --logdir logs/ \
               --etc-portage etc-portage/ \
-              media-gfx/optipng
+              sys-process/htop
 
           find logs/ packages/
 
           gentoo-packages --pkgdir packages/ list
           sudo chown -R "${USER}:${USER}" packages/
-          gentoo-packages --pkgdir packages/ delete --metadata media-gfx/optipng
+          gentoo-packages --pkgdir packages/ delete --metadata sys-process/htop
           gentoo-packages --pkgdir packages/ list
 
           find packages/


### PR DESCRIPTION
`media-gfx/optipng-7.9.1` started pulling in things like CMake which slows down a build from scratch significantly.